### PR TITLE
added python setuptools support in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ or [read it online](https://retweet.readthedocs.org/en/latest/).
 
         # pip3 install retweet
 
-* Install Retweet from sources
-
-* (see the installation guide for full details)
-  [Installation Guide](http://retweet.readthedocs.org/en/latest/install.html)
+* Install Retweet from sources    
+  *(see the installation guide for full details)
+  [Installation Guide](http://retweet.readthedocs.org/en/latest/install.html)*
+  
 
         # tar zxvf retweet-0.6.tar.gz
         # cd retweet

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ or [read it online](https://retweet.readthedocs.org/en/latest/).
 
 * Install Retweet from sources
 
+* (see the installation guide for full details)
+  [Installation Guide](http://retweet.readthedocs.org/en/latest/install.html)
+
         # tar zxvf retweet-0.6.tar.gz
         # cd retweet
         # python3.4 setup.py install

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -7,6 +7,14 @@ From PyPI
 From sources
 ^^^^^^^^^^^^
 * You need at least Python 3.4.
+* On some Linux Distribution setuptools package does not come with default python install, you need to install it.
+  
+    $ wget https://bootstrap.pypa.io/ez_setup.py -O - | sudo python
+	  
+	  * Alternatively, Setuptools may be installed to a user-local path:
+	  
+	       $ wget https://bootstrap.pypa.io/ez_setup.py -O - | python - --user
+
 * Untar the tarball and go to the source directory with the following commands::
 
     $ tar zxvf retweet-0.6.tar.gz

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -7,13 +7,20 @@ From PyPI
 From sources
 ^^^^^^^^^^^^
 * You need at least Python 3.4.
-* On some Linux Distribution setuptools package does not come with default python install, you need to install it.
+
+* On some Linux Distribution **setuptools** package does not come with default python install, you need to install it.
+
+* Install **PIP**::
+
+    	$ wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python3.4
+    
+    
+* Install **setuptools** module::    
   
-    $ wget https://bootstrap.pypa.io/ez_setup.py -O - | sudo python
+    $ wget https://bootstrap.pypa.io/ez_setup.py -O - | sudo python3.4 
+  (Alternatively, Setuptools may be installed to a user-local path)::
 	  
-	  * Alternatively, Setuptools may be installed to a user-local path:
-	  
-	       $ wget https://bootstrap.pypa.io/ez_setup.py -O - | python - --user
+	       $ wget https://bootstrap.pypa.io/ez_setup.py -O - | python3.4 - --user
 
 * Untar the tarball and go to the source directory with the following commands::
 


### PR DESCRIPTION
when installing retweet from source as issue opened by @HumanG33k, default python 3.4 install in debian or debian based distros(ubuntu 15.10) don't have setuptools package installed. User need to install setuptools package manually.